### PR TITLE
Move tag from 'master' → 'latest' for upstream pihole image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pihole/pihole:master-buster
+FROM pihole/pihole:latest
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG FTLVER=v5.11

--- a/Dockerfile.edge
+++ b/Dockerfile.edge
@@ -1,4 +1,4 @@
-FROM pihole/pihole:master
+FROM pihole/pihole:dev
 ARG TARGETARCH
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG FTLVER=v5.11


### PR DESCRIPTION
After spending some time trying to figure out why the version of the pihole was outdated, I asked the devs: pi-hole/docker-pi-hole#934 They said the `master` tag is no longer being built and that the only valid tags now are:
* `latest`
* `dev`
* `nightly`

This PR changes the tag of the `docker-pi-hole` image from `master` to `latest`.